### PR TITLE
Listing any name encoded in the certificates's subject alternative names field

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,6 @@ programatically. It can be run from command line:
 
 Known bugs and quirks:
 
-- subject alternative name now only shows DNS names (other types are ignored)
 - name constraints don't distinguish among various GeneralName subtypes
 - some extensions are not shown very nicely when put in string format
 - not all extensions are supported

--- a/pyx509/pkcs7_models.py
+++ b/pyx509/pkcs7_models.py
@@ -31,6 +31,7 @@ from pkcs7.asn1_models.certificate_extensions import *
 from pkcs7.debug import *
 from pkcs7.asn1_models.decoder_workarounds import decode
 import datetime, time
+import collections
 
 class CertificateError(Exception):
     pass
@@ -192,11 +193,11 @@ class SubjectAltNameExt():
     def __init__(self, asn1_subjectAltName):
         # Creates a dictionary for the component types found in
         # SubjectAltName. Each dictionary entry is a list of names
-        self.names = collections.defaultdict(list)
+        self.values = collections.defaultdict(list)
         for gname in asn1_subjectAltName:
             component_type = gname.getName()
             name = unicode(gname.getComponent())
-            names[component_type].append(name)
+            self.values[component_type].append(name)
 
 class BasicConstraintsExt():
     '''

--- a/pyx509/x509_parse.py
+++ b/pyx509/x509_parse.py
@@ -38,12 +38,12 @@ if __name__ == "__main__":
 	if len(sys.argv) < 2:
 		print >> sys.stderr, "Usage: x509_parse.py certificate.der"
 		sys.exit(1)
-	
+
 	der_file = sys.argv[1]
-		
+
 	x509cert = x509_parse(file(der_file).read())
 	tbs = x509cert.tbsCertificate
-	
+
 	print "X.509 version: %d (0x%x)" % (tbs.version + 1, tbs.version)
 	print "Serial no: 0x%x" % tbs.serial_number
 	print "Signature algorithm:", x509cert.signature_algorithm
@@ -54,15 +54,15 @@ if __name__ == "__main__":
 	print "Subject:", str(tbs.subject)
 	print "Subject Public Key Info:"
 	print "\tPublic Key Algorithm:", tbs.pub_key_info.algName
-	
+
 	if tbs.issuer_uid:
 		print "Issuer UID:", hexlify(tbs.issuer_uid)
 	if tbs.subject_uid:
 		print "Subject UID:", hexlify(tbs.subject_uid)
-	
+
 	algType = tbs.pub_key_info.algType
 	algParams = tbs.pub_key_info.key
-	
+
 	if (algType == PublicKeyInfo.RSA):
 		print "\t\tModulus:", hexlify(algParams["mod"])
 		print "\t\tExponent:", algParams["exp"]
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 		print "\t\tG:", hexlify(algParams["g"]),
 	else:
 		print "\t\t(parsing keys of this type not implemented)"
-	
+
 	print "\nExtensions:"
 	if tbs.authInfoAccessExt:
 		print "\tAuthority Information Access Ext: is_critical:", tbs.authInfoAccessExt.is_critical
@@ -90,13 +90,13 @@ if __name__ == "__main__":
 			print "\t\tcert serial no", aki.auth_cert_sn
 		if hasattr(aki, "auth_cert_issuer"):
 			print "\t\tissuer", aki.auth_cert_issuer
-			
+
 	if tbs.basicConstraintsExt:
 		print "\tBasic Constraints Ext: is_critical:", tbs.basicConstraintsExt.is_critical
 		bc = tbs.basicConstraintsExt.value
 		print "\t\tCA:", bc.ca
 		print "\t\tmax_path_len:", bc.max_path_len
-	
+
 	if tbs.certPoliciesExt:
 		print "\tCert Policies Ext: is_critical:", tbs.certPoliciesExt.is_critical
 		policies = tbs.certPoliciesExt.value
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 			for qualifier in policy.qualifiers:
 				print "\t\t\toid:", qualifier.id
 				print "\t\t\tqualifier:", qualifier.qualifier
-		
+
 	if tbs.crlDistPointsExt:
 		print "\tCRL Distribution Points: is_critical:", tbs.crlDistPointsExt.is_critical
 		crls = tbs.crlDistPointsExt.value
@@ -116,13 +116,13 @@ if __name__ == "__main__":
 				print "\t\tissuer:", crl.issuer
 			if crl.reasons:
 				print "\t\treasons:", crl.reasons
-	
+
 	if tbs.extKeyUsageExt:
 		print "\tExtended Key Usage: is_critical:", tbs.extKeyUsageExt.is_critical
 		eku = tbs.extKeyUsageExt.value
 		set_flags = [flag for flag in ExtendedKeyUsageExt._keyPurposeAttrs.values() if getattr(eku, flag)]
 		print "\t\t", ",".join(set_flags)
-			
+
 	if tbs.keyUsageExt:
 		print "\tKey Usage: is_critical:", tbs.keyUsageExt.is_critical
 		ku = tbs.keyUsageExt.value
@@ -130,24 +130,25 @@ if __name__ == "__main__":
 			 "dataEncipherment", "keyAgreement", "keyCertSign",
 			 "cRLSign", "encipherOnly", "decipherOnly",
 			]
-		
+
 		set_flags = [flag for flag in flags if getattr(ku, flag)]
 		print "\t\t", ",".join(set_flags)
-	
+
 	if tbs.policyConstraintsExt:
 		print "\tPolicy Constraints: is_critical:", tbs.policyConstraintsExt.is_critical
 		pc = tbs.policyConstraintsExt.value
-		
+
 		print "\t\trequire explicit policy: ", pc.requireExplicitPolicy
 		print "\t\tinhibit policy mapping: ", pc.inhibitPolicyMapping
-	
+
 	#if tbs.netscapeCertTypeExt: #...partially implemented
-	
+
 	if tbs.subjAltNameExt:
 		print "\tSubject Alternative Name: is_critical:", tbs.subjAltNameExt.is_critical
 		san = tbs.subjAltNameExt.value
-		print "\t\tDNS names:", ",".join(san.names) #only DNS names supported now
-		
+        for component_type, name_list in san.values.items():
+			print "\t\t%s: %s" % (component_type, ",".join(name_list))
+
 	if tbs.subjKeyIdExt:
 		print "\tSubject Key Id: is_critical:", tbs.subjKeyIdExt.is_critical
 		ski = tbs.subjKeyIdExt.value
@@ -156,7 +157,7 @@ if __name__ == "__main__":
 	if tbs.nameConstraintsExt:
 		nce = tbs.nameConstraintsExt.value
 		print "\tName constraints: is_critical:", tbs.nameConstraintsExt.is_critical
-		
+
 		subtreeFmt = lambda subtrees: ", ".join([str(x) for x in subtrees])
 		if nce.permittedSubtrees:
 			print "\t\tPermitted:", subtreeFmt(nce.permittedSubtrees)
@@ -164,4 +165,4 @@ if __name__ == "__main__":
 			print "\t\tExcluded:", subtreeFmt(nce.excludedSubtrees)
 
 	print "Signature:", hexlify(x509cert.signature)
-		
+


### PR DESCRIPTION
Changes to allow any subject alt  name to be decoded and listed. My use case calls for listing URIs listed in certificates.

PS: Looks like my vim is stripping away spaces on empty lines. Do you need me to resubmit the PR w/out the cleanup?

Cheers,
Lmwangi