### PR TITLE
Extend SubjectAlt names to accept IP,DNS and URIs

### DIFF
--- a/README
+++ b/README
@@ -30,7 +30,6 @@ programatically. It can be run from command line:
 
 Known bugs and quirks:
 
-- subject alternative name now only shows DNS names (other types are ignored)
 - name constraints don't distinguish among various GeneralName subtypes
 - some extensions are not shown very nicely when put in string format
 - not all extensions are supported

--- a/pyx509/x509_parse.py
+++ b/pyx509/x509_parse.py
@@ -146,7 +146,8 @@ if __name__ == "__main__":
 	if tbs.subjAltNameExt:
 		print "\tSubject Alternative Name: is_critical:", tbs.subjAltNameExt.is_critical
 		san = tbs.subjAltNameExt.value
-		print "\t\tDNS names:", ",".join(san.names) #only DNS names supported now
+		for component_type, name_list in san.values.items():
+			print "\t\t%s: %s" % (component_type, ",".join(name_list))
 		
 	if tbs.subjKeyIdExt:
 		print "\tSubject Key Id: is_critical:", tbs.subjKeyIdExt.is_critical


### PR DESCRIPTION
Opening  a new PR in favour of #6. This PR adds support for SANs of type:
* DNS (tested)
* IP Address (tested)
* URI (tested)

Testing output:
```
	Subject Alternative Name: is_critical: False
		iPAddress: 1.2.3.4
		dNSName: feel-good.org
		uniformResourceIdentifier: authority://host/path
	Subject Key Id: is_critical: False
```