### PR TITLE
Handle Subject Alternate Names with Unicode in them.

### DIFF
--- a/pyx509/pkcs7_models.py
+++ b/pyx509/pkcs7_models.py
@@ -201,7 +201,7 @@ class SubjectAltNameExt():
             if component_type == 'iPAddress':
                 name = self.mk_ip_addr(gname.getComponent())
             else:
-                name = unicode(gname.getComponent())
+                name = unicode(str(gname.getComponent()), 'utf-8')
             self.values[component_type].append(name)
 
     def mk_ip_addr(self, octets):


### PR DESCRIPTION
I'm not sure this is the 'best' way to do this, but it does fix the problem.  

Example Certificate:

<pre>
echo "-----BEGIN CERTIFICATE-----
MIII+DCCBuCgAwIBAgICAYkwDQYJKoZIhvcNAQEFBQAwgYExCzAJBgNVBAYTAkVTMRQwEgYDVQQK
DAtJWkVOUEUgUy5BLjE4MDYGA1UECwwvQlogWml1cnRhZ2lyaSBwdWJsaWtvYSAtIENlcnRpZmlj
YWRvIHB1YmxpY28gRVYxIjAgBgNVBAMMGUNBIGRlIENlcnRpZmljYWRvcyBTU0wgRVYwHhcNMTQw
MjA3MTEwOTIxWhcNMTYwMjA3MTEwOTIxWjCB8zETMBEGCysGAQQBgjc8AgEDEwJFUzEaMBgGA1UE
DwwRR292ZXJubWVudCBFbnRpdHkxCzAJBgNVBAYTAkVTMTQwMgYDVQQKDCtBQkFEScORT0tPIFVE
QUxBIC0gQVlVTlRBTUlFTlRPIERFIEFCQURJw5FPMRowGAYDVQQLDBFzZWRlIGVsZWN0csOzbmlj
YTEyMDAGA1UECwwpQUJBREnDkU9LTyBVREFMQS9BWVVOVEFNSUVOVE8gREUgQUJBREnDkU8xEjAQ
BgNVBAUTCVA0ODAwMTAwQjEZMBcGA1UEAwwQd3d3LmFiYWRpw7FvLm9yZzCCASIwDQYJKoZIhvcN
AQEBBQADggEPADCCAQoCggEBAKRrqmNyAXmKTTFuOWdM1pYNi14Jl0IW9zFFDANRM+wwJ0nMkBiA
9i/cZKgBg2uhin9cXmhJoxMTWI9MdGO1TPLdCMQ0IncEqxLNi6erQ9UlOpbOUV3RestEsd0SpLw2
1HV11c2WKQlLSnDpTdpnkPlQ77XOvc+N0JYrwR4ENH59JEboUocvF4kSJtZqTDrO1N9mcD/APhcT
nkfBuWm3rwhsnQs6pIQ/NgBVmNLS6+uQJMvph0sq+P3uRCeY3uYB0+/yR+gn9Ux20urMohd2UeEj
70I0I3mRTUnTZdC1gKorbQwiKSGowqNYQuvcvTXOu1MT/brIHmsBqJ9785pWIwsCAwEAAaOCBAQw
ggQAMIHHBgNVHRIEgb8wgbyGFWh0dHA6Ly93d3cuaXplbnBlLmNvbYEPaW5mb0BpemVucGUuY29t
pIGRMIGOMUcwRQYDVQQKDD5JWkVOUEUgUy5BLiAtIENJRiBBMDEzMzcyNjAtUk1lcmMuVml0b3Jp
YS1HYXN0ZWl6IFQxMDU1IEY2MiBTODFDMEEGA1UECQw6QXZkYSBkZWwgTWVkaXRlcnJhbmVvIEV0
b3JiaWRlYSAxNCAtIDAxMDEwIFZpdG9yaWEtR2FzdGVpejCCARYGA1UdEQSCAQ0wggEJgRZpZGF6
a2FyaTFAYWJhZGlhbm8ub3JnpIHWMIHTMR8wHQYJYIVUAQMFAQIFDBB3d3cuYWJhZGnDsW8ub3Jn
MTgwNgYJYIVUAQMFAQIEDClBQkFEScORT0tPIFVEQUxBL0FZVU5UQU1JRU5UTyBERSBBQkFEScOR
TzEYMBYGCWCFVAEDBQECAwwJUDQ4MDAxMDBCMTowOAYJYIVUAQMFAQICDCtBQkFEScORT0tPIFVE
QUxBIC0gQVlVTlRBTUlFTlRPIERFIEFCQURJw5FPMSAwHgYJYIVUAQMFAQIBDBFzZWRlIGVsZWN0
csOzbmljYYIWd3d3LnhuLS1hYmFkaW8tMHdhLm9yZzATBgNVHSUEDDAKBggrBgEFBQcDATAdBgNV
HQ4EFgQUzSOtA7doONOu1u1eQnDrkLVDNKEwHwYDVR0jBBgwFoAUps5paS6mITU7Os8K8S4/FawZ
kCcwggEeBgNVHSAEggEVMIIBETCCAQ0GCisGAQQB8zkGAQIwgf4wJQYIKwYBBQUHAgEWGWh0dHA6
Ly93d3cuaXplbnBlLmNvbS9jcHMwgdQGCCsGAQUFBwICMIHHGoHEQmVybWVlbiBtdWdhayBlemFn
dXR6ZWtvIHd3dy5pemVucGUuY29tIFppdXJ0YWdpcmlhbiBrb25maWFudHphIGl6YW4gYXVycmV0
aWsga29udHJhdHVhIGlyYWt1cnJpLkxpbWl0YWNpb25lcyBkZSBnYXJhbnRpYXMgZW4gd3d3Lml6
ZW5wZS5jb20gQ29uc3VsdGUgZWwgY29udHJhdG8gYW50ZXMgZGUgY29uZmlhciBlbiBlbCBjZXJ0
aWZpY2FkbzAyBggrBgEFBQcBAQQmMCQwIgYIKwYBBQUHMAGGFmh0dHA6Ly9vY3NwLml6ZW5wZS5j
b20wJQYIKwYBBQUHAQMEGTAXMAgGBgQAjkYBATALBgYEAI5GAQMCAQ8wDgYDVR0PAQH/BAQDAgWg
MDgGA1UdHwQxMC8wLaAroCmGJ2h0dHA6Ly9jcmwuaXplbnBlLmNvbS9jZ2ktYmluL2NybHNzbGV2
MjANBgkqhkiG9w0BAQUFAAOCAgEAWbMXpuJutAOA2W6pIOIa7OL/6MGTaaXQstNLgMFEmGwJUxZP
EfAxoN/r8vA35hU8x6yIuvHBMwT4t3cDJRV/r5nGHVofsfkeiCywWMZpeJ6h/GjHxRg4nopiandG
jBHw8fQ68MWHk4YQN5BOxKwU0RyuO0D5OV6eH16Rrk9TNPaojFgAyC5NsrapFR5nvn+wjl9xyuOE
Gz9wHuh6QmEYO4usPWZEFFNruVjVZUNJGFRxOyA2YsAZ1vxjMLqsOkSgqFd5spd1YyJKfrl1tIi+
9GkPmdkHiCdCsFYLn3qL8zSEui9W+7XvdTnEgJpyCW2tw2Ee7G0vpfxLR/JD+VzpAnRBKCQGvjKG
/3SjY5f0SxESuXqi1v0irCzF1RHvI38P67TnUG4Lbe8jwwDWZMQkhncHF/qRlhzwU2DXCPHEq7f9
FqmYTrkBwWyrfatj8LjZCb/RBEontEtFmnDplBIKf4G2uLWXoDj6MrxT5KaPcLuej/4TCuQZm7k1
puBJmK8zwjy58BCWRvxgeGhTf/rHno0Tx+o2zEDvebNpz/svUvD/yAmMLRKl4EIUHChb1Oa52uyW
peuJawHDOrD3kbehgwW1K34gY7RXkiWEKXWBQAvhylXhed8wU9Xv7M9BwchQeBJMSSQJ4EfX2jEi
T4CFqda32sxA6GrSt5UktIkZBl4=
-----END CERTIFICATE-----" | openssl x509 -noout -text
</pre>
